### PR TITLE
Install script now creates lib/etc for options.php

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -956,7 +956,21 @@ class PeoplePod {
 				return false;
 			}
 		}
-				
+
+		if (!file_exists($this->libOptions('etcPath'))) {
+		  echo "<p>The directory <b>{$this->libOptions('etcPath')}</b> does not exist. Attempting to create it...";
+		  
+		  mkdir($this->libOptions('etcPath'));
+		  if (file_exists($this->libOptions('etcPath'))) {
+		    echo "success!</p>";
+		  } else {
+		    echo "failed :(</p>";
+		  }
+		} else {
+		  echo "<p>{$this->libOptions('etcPath')} exists.</p>";
+		}
+		
+		
 		$file = $this->libOptions('etcPath') . "/options.php";
 		$fh = fopen($file, 'w');
 		if (!$fh) { $this->throwError("Can't open config file!  Check file permissions on " . $this->libOptions('etcPath') . "/options.php"); return false; }


### PR DESCRIPTION
I noticed that, now PeoplePods is on Git, the lib/etc folder no longer exists in a fresh install. I've amended the installation script so that, if the lib/etc folder doesn't exist at install-time, it's created. 

Hope you like my change!
