### PR TITLE
check existance of callback parameter

### DIFF
--- a/pods/core_api_simple/index_version2.php
+++ b/pods/core_api_simple/index_version2.php
@@ -574,7 +574,7 @@
 	
 	function results($data,$format='json') {
 		// if a callback function has been passed in as a parameter, this is a jsonP request
-		if ($func = $_GET['callback']) { 
+		if (isset($_GET['callback']) && $func = $_GET['callback']) { 
 		
 			return "{$func}(" . json_encode($data) . ")";
 		


### PR DESCRIPTION
check that callback exists before reference to avoid error messages in
log
